### PR TITLE
Adding Flexible to the sidebar

### DIFF
--- a/zendesk-package/manifest.json
+++ b/zendesk-package/manifest.json
@@ -10,8 +10,16 @@
   "signedUrls": true,
   "location": {
     "support": {
-      "ticket_sidebar": "https://search.cloud.coveo.com/pages/zendesk",
-      "new_ticket_sidebar": "https://search.cloud.coveo.com/pages/zendesk",
+      "ticket_sidebar": {
+        "url": "https://search.cloud.coveo.com/pages/zendesk",
+        "flexible": true,
+        "autoload": false
+        }
+      "new_ticket_sidebar": {
+        "url": "https://search.cloud.coveo.com/pages/zendesk",
+        "flexible": true,
+        "autoload": false
+        }
       "top_bar": "https://search.cloud.coveo.com/pages/zendesk"
     }
   },


### PR DESCRIPTION
There was a recent release of Zendesk that allows the bar to be scaled by the user.  Adding Flexible to the manifest file will allow the sidebar app to scale with the portion selected by the user.  This is extremely valuable for Coveo when viewing documentation that could be larger at times.